### PR TITLE
Notifier module never fails when no user enabled email notification

### DIFF
--- a/tendrl/notifier/notification/handlers/mail_handler.py
+++ b/tendrl/notifier/notification/handlers/mail_handler.py
@@ -176,6 +176,7 @@ class EmailHandler(NotificationPlugin):
                         'alert notification'
                     }
                 )
+                return
         except (
             AttributeError,
             EtcdException,


### PR DESCRIPTION
tendrl-bug-id: Tendrl/notifier#103

Signed-off-by: GowthamShanmugam <gshanmug@redhat.com>